### PR TITLE
create comment entity & mapping

### DIFF
--- a/fillYourself/src/main/java/my/fillYourself/entity/Board.java
+++ b/fillYourself/src/main/java/my/fillYourself/entity/Board.java
@@ -11,10 +11,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 @Builder
+@Table(name="board")
 public class Board extends BaseEntity {
 
     @Id
-    @Column(name = "board_ID")
+    @Column(name = "board_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/fillYourself/src/main/java/my/fillYourself/entity/Comment.java
+++ b/fillYourself/src/main/java/my/fillYourself/entity/Comment.java
@@ -1,0 +1,22 @@
+package my.fillYourself.entity;
+
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "comment")
+@NoArgsConstructor
+public class Comment extends BaseEntity{
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String content;
+
+    @ManyToOne // 다대일 관계 설정
+    @JoinColumn(name="board_id") // name 속성으로 매핑할 외래키 이름을 지정함
+    private Board board;
+
+}


### PR DESCRIPTION
하이버네이트 네이밍 규칙으로 @Table(name='')으로 지정안하면  연관관계 매칭관련 테이블 활용해서 comment라 기대 but board_comment로 생성됨. @JoinColumn이 외래키 매핑 설정, @ManyToOne/@OneToMany와 같이 지정하기